### PR TITLE
map/filter: show list comprehensions as well

### DIFF
--- a/VimScriptForPythonDevelopers.MD
+++ b/VimScriptForPythonDevelopers.MD
@@ -772,7 +772,8 @@ endif
 
 **Python:**
 ```python
-odd = filter(lambda x: x %2, range(10))
+odd = list(filter(lambda x: x % 2, range(10)))
+odd = [x for x in range(10) if x % 2]
 ```
 
 **VimScript:**
@@ -786,7 +787,8 @@ let odd = filter(range(10), {idx, v -> v % 2})
 
 **Python:**
 ```python
-num_str = map(lambda x: str(x), range(10))
+num_str = list(map(lambda x: str(x), range(10)))
+num_str = [str(x) for x in range(10)]
 ```
 
 **VimScript:**


### PR DESCRIPTION
Python programmers often use list comprehensions instead of map/filter, let's show how that would look.

Also, in Python 3 map/filter are lazily evaluated; if you want a list back, you need to wrap the map/filter in a list().