### PR TITLE
Clarify and correct readlines/writelines examples

### DIFF
--- a/VimScriptForPythonDevelopers.MD
+++ b/VimScriptForPythonDevelopers.MD
@@ -1942,11 +1942,13 @@ Vim has a function to read the entire file but doesn't have a function to read a
 ```python
 with open('myfile.txt', 'r') as f:
     lines = f.readlines()
+# lines == ['line1\n', 'line2\n'] 
 ```
 
 **VimScript:**
 ```vim
 let lines = readfile("myfile.txt")
+" lines == ['line1', 'line2'] 
 ```
 
 *Help:* [readfile()](https://vimhelp.org/eval.txt.html#readfile%28%29)
@@ -1954,9 +1956,13 @@ let lines = readfile("myfile.txt")
 ### Writing lines to a file
 **Python:**
 ```python
+lines = ['line1\n', 'line2\n']
+with open('myfile.txt', 'w') as fh:
+    fh.writelines(lines)
+    
 lines = ['line1', 'line2']
 with open('myfile.txt', 'w') as fh:
-    fh.writelines("\n".join(lines))
+    print(*lines, sep='\n', file=fh)
 ```
 
 **VimScript:**


### PR DESCRIPTION
Show that Python's fileobj.readlines() returns lines with line terminators, while vim's readlines() returns lines without the terminators.

Correct the writelines example: the code as written passed a string instead of a list of strings, which actually works, but very inefficiently (writing one character at a time).  A better way would be to `fh.write('\n'.join(lines))`, but that is still incorrect: it omits the trailing newline which is mandatory/customary on text files in Unix-like OSes.  Instead show how to print multiple lines using the print() function in Python 3 if you need the newlines to be added, and show how to use writelines() if the newlines are already there.