### PR TITLE
Correct Python date and time example

### DIFF
--- a/VimScriptForPythonDevelopers.MD
+++ b/VimScriptForPythonDevelopers.MD
@@ -2168,9 +2168,9 @@ atan2| `f = math.atan2(0.4, 0.8)` | `let f = atan2(0.4, 0.8)`
 
 **Python:**
 ```python
-from datetime import date
-d = date.today()
-print d.strftime("%c")
+from datetime import datetime
+d = datetime.now()
+print(d.strftime("%c"))
 ```
 
 **VimScript:**


### PR DESCRIPTION
datetime.date.today().strftime("%c") prints the time as 00:00:00 because datetime.date does not store time information.  Use datetime.datetime.now().strftime("%c").

Technically, to be closer to vim, the Python code should also `import locale` and call `locale.setlocale(locale.LC_TIME, "")` to use the user's locale instead of C.  It seem too much for the simple example.

I also made the example code work on Python 3 where `print()` is a function and requires parentheses.