### PR TITLE
Correct line counting in Python example

### DIFF
--- a/VimScriptForPythonDevelopers.MD
+++ b/VimScriptForPythonDevelopers.MD
@@ -2245,7 +2245,7 @@ procObj = subprocess.Popen('grep class *.java',
 			stdout=subprocess.PIPE,
 			shell=True)
 lines, err = procObj.communicate()
-print("Number of matches = " + str(len(lines.split("\n"))))
+print("Number of matches = " + str(len(lines.splitlines())))
 ```
 
 **VimScript:**


### PR DESCRIPTION
`'line 1\nline 2\n'.split('\n') == ['line 1', 'line 2', '']`

`'line 1\nline 2\n'.splitlines() == ['line 1', 'line 2']`