### PR TITLE
Fix either-or branch and negative lookbehind examples in regex table

### DIFF
--- a/VimScriptForPythonDevelopers.MD
+++ b/VimScriptForPythonDevelopers.MD
@@ -2662,7 +2662,7 @@ non-capturing match| `(?:...)` | `\%(...\)`
 positive look-ahead| `(?=...)` | `\(...\)\@=`
 negative look-ahead| `(?!...)` | `\(...\)\@!`
 positive look-behind| `(?<=...)` | `\(...\)\@<=`
-negative look-behind| `(?\<!...)` | `\(...\)\@<!`
+negative look-behind| `(?<!...)` | `\(...\)\@<!`
 start of word| `\b` | `\<`
 end of word| `\b` | `\>`
 digit| `\d` | `\d`

--- a/VimScriptForPythonDevelopers.MD
+++ b/VimScriptForPythonDevelopers.MD
@@ -2656,7 +2656,7 @@ m to n non-greedy matches| `{m,n}?` | `\{-m,n}`
 character class| `[...]` | `[...]`
 negated character class| `[^...]` | `[^...]`
 range| `[a-z]` | `[a-z]`
-either-or branch| `|` | `\|`
+either-or branch| `\|` | `\\|`
 capturing group| `(...)` | `\(...\)`
 non-capturing match| `(?:...)` | `\%(...\)`
 positive look-ahead| `(?=...)` | `\(...\)\@=`

--- a/VimScriptForPythonDevelopers.MD
+++ b/VimScriptForPythonDevelopers.MD
@@ -2639,7 +2639,7 @@ echo s
 
 ### Regular expression comparison
 
-Note that the below table contains only the regular expressions that are present in both Python and Vim. There are some minor differences between the behavior of Vim and Python regular expression atoms listed below. For example, in Python the (?i) atom ignores case after the atom. But in Vim, the \c atom ignores case everywhere before and after the atom. Refer to the help pages for these atoms for more information.
+Note that the below table contains only the regular expressions that are present in both Python and Vim.
 
 What|Python|Vim
 ----|------|---


### PR DESCRIPTION
Markdown sees the `|` and treats it as a table cell separator, unless preceded by a backslash.

I had to do trial and error to figure out how many backslashes are needed to produce a backslash-vertical-pipe.

And it's not true that `(?i)` affects only things following it.  It affects everything:

```
>>> re.findall('need(?i)le', 'haystack haystack NEEDLE haystack')
<stdin>:1: DeprecationWarning: Flags not at the start of the expression 'need(?i)le'
['NEEDLE']
```